### PR TITLE
Docker compose for non-authN/Z OIDC setup of SSM + CD of keycloak image

### DIFF
--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - '*'
-    paths:
-      - "keycloak/**"
+    #paths:
+    #  - "keycloak/**"
 
 jobs:
 
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: [check-keycloa-build]
+    needs: [check-keycloak-build]
     steps:
       -
         name: Checkout

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - '*'
-    #paths:
-    #  - "keycloak/**"
+    paths:
+      - "keycloak/**"
 
 jobs:
 

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/checkout@v3
       - 
         name: Build keycloak contianer
-        run: docker build -t ssm-keycloak .
+        run: |
+          cd keycloak
+          docker build -t ssm-keycloak .
 
   publish-container-image:
     strategy:
@@ -51,7 +53,8 @@ jobs:
         name: Build and push keycloak image
         uses: docker/build-push-action@v4
         with:
-          context: .
+          context: ./keycloak
+          file: ./keycloak/Dockerfile
           push: true 
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -1,0 +1,57 @@
+name: Code checks
+ 
+on:
+  push:
+    branches:
+      - '*'
+    paths:
+      - "keycloak/**"
+
+jobs:
+
+  check-keycloak-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      - 
+        name: Build keycloak contianer
+        run: docker build -t ssm-keycloak .
+
+  publish-container-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [code-checks]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push keycloak image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true 
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -1,4 +1,4 @@
-name: Code checks
+name: Keycloak 
  
 on:
   push:
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: [code-checks]
+    needs: [check-keycloa-build]
     steps:
       -
         name: Checkout

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,14 +1,20 @@
-Running:
+# SSM Keycloak for OpenID Connect Identity Provider
 
+Keycloak configured for SSM project. 
+
+Serves as the identity provider for OpenID Connect (OIDC)
+
+### Quickstart
+
+Run:
+```
 docker-compose up
+```
 
 Configuring:
-
-Remove FEDERATE_LDAP to turn off user federation. LDAP_URL and USERDN must be configured for federation.
-
-Remove GOOGLE_IDP to prevent users from loggin in with Google accounts. GOOGLE_CLIENT_ID and GOOGLE_SECRET must be set for Google authentication.
-
-To configure as a production server, uncomment HTTPS and set HOSTNAME correctly.
+* Remove `FEDERATE_LDAP` to turn off user federation. `LDAP_URL` and USERDN must be configured for federation.
+* Remove `GOOGLE_IDP` to prevent users from loggin in with Google accounts. `GOOGLE_CLIENT_ID` and `GOOGLE_SECRET` must be set for Google authentication.
+* To configure as a production server, uncomment `HTTPS` and set `HOSTNAME` correctly.
 
 
 

--- a/no-auth/.env
+++ b/no-auth/.env
@@ -1,0 +1,4 @@
+MONGO_USERNAME=user
+MONGO_PASSWORD=changeme
+APP_PROTOCOL=http
+APP_HOSTNAME=localhost

--- a/no-auth/docker-compose.yml
+++ b/no-auth/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.7"
+
+services:
+  ssm-service-catalog-graph-db:
+    image: ghcr.io/smart-spectral-matching/ssm-service-catalog-graph-db:15-add-apache-jena-fuseki-triple-store-database-image-to-cd-d6b3c36dcf8f9df7ee11cb3503948b6fa7ae0708
+    restart: unless-stopped
+    volumes:
+      - ./catalog-graph-db/databases:/opt/apache-jena-fuseki/run/databases
+      - ./catalog-graph-db/backups:/opt/apache-jena-fuseki/run/backups
+      - ./catalog-graph-db/configuration:/opt/apache-jena-fuseki/run/configuration
+      - ./catalog-graph-db/logs:/opt/apache-jena-fuseki/run/logs
+      - ./catalog-graph-db/system:/opt/apache-jena-fuseki/run/system
+      - ./catalog-graph-db/system_files:/opt/apache-jena-fuseki/run/system_files
+      - ./catalog-graph-db/templates:/opt/apache-jena-fuseki/run/templates
+
+  ssm-service-catalog-document-store:
+    image: mongo:4
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+    volumes:
+      - ./catalog-document-store:/data/db
+  
+  ssm-service-file-converter:
+    image: ghcr.io/smart-spectral-matching/ssm-service-file-converter:v0.2.0
+    ports:
+      - "8000:8000"
+
+  ssm-service-catalog:
+    image: ghcr.io/smart-spectral-matching/ssm-service-catalog:main-f0eed18aba1420ec94482f5b8e99771428a1c372
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on: 
+      - ssm-service-catalog-graph-db
+      - ssm-service-catalog-document-store
+    command: "java -jar /app.jar -Dspring.profiles.active=localdockerfileconverter --app.jsonconversion=file_converter_service --spring.data.mongodb.host=ssm-service-catalog-document-store --app.fuseki.hostname=http://ssm-service-catalog-graph-db --app.fileconverter.uri=http://ssm-service-file-converter:8000 --app.host=$APP_PROTOCOL://$APP_HOSTNAME --spring.data.mongodb.username=$MONGO_USERNAME --spring.data.mongodb.password=$MONGO_PASSWORD"


### PR DESCRIPTION
Closes #3
Closes #4

Work includes:
  - Publishing keycloak image when changes are made to the keycloak directory
  - Adds a `no-auth` directory with docker compose setup for SSM deployment w/o authN/Z

I tested the docker compose file locally with CURIES