### PR TITLE
Adds additional <branch name>-latest image tag for keycloak + updates to keycloak actions yaml

### DIFF
--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -60,4 +60,3 @@ jobs:
           tags: |
             ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-latest
             ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}
-            ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -1,6 +1,7 @@
 name: Keycloak 
  
 on:
+  workflow_dispatch:
   push:
     branches:
       - '*'

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - '*'
-    #paths:
-    #  - "keycloak/**"
+    paths:
+      - "keycloak/**"
 
 jobs:
 
@@ -19,7 +19,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - 
         name: Build keycloak contianer
         run: |
@@ -36,23 +36,23 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push keycloak image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./keycloak
           file: ./keycloak/Dockerfile

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -57,4 +57,40 @@ jobs:
           file: ./keycloak/Dockerfile
           push: true 
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}
+          tags: |
+            publish-container-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [check-keycloak-build]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push keycloak image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./keycloak
+          file: ./keycloak/Dockerfile
+          push: true 
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-latest
+            ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}
+            ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - '*'
-    paths:
-      - "keycloak/**"
+    #paths:
+    #  - "keycloak/**"
 
 jobs:
 

--- a/.github/workflows/keycloak.yaml
+++ b/.github/workflows/keycloak.yaml
@@ -58,39 +58,6 @@ jobs:
           push: true 
           platforms: linux/amd64,linux/arm64
           tags: |
-            publish-container-image:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [check-keycloak-build]
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push keycloak image
-        uses: docker/build-push-action@v4
-        with:
-          context: ./keycloak
-          file: ./keycloak/Dockerfile
-          push: true 
-          platforms: linux/amd64,linux/arm64
-          tags: |
             ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-latest
             ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}
             ghcr.io/smart-spectral-matching/ssm-keycloak:${{ github.ref_name }}-${{github.sha}}


### PR DESCRIPTION
This simply adds a `<branch name>-latest` tag to the docker image.

Currently, we are only putting out only tags with git commit SHA in them, such as:
  - `ghcr.io/smart-spectral-matching/ssm-keycloak:main-51536911d706466dde54188a43eaa54cf14171c0`

This is to simply add a nicer tag that stays up with a branch's latest image, so we will additionally have:
  - `ghcr.io/smart-spectral-matching/ssm-keycloak:main-latest`

We would also like to eventually add release tags. Issue https://github.com/smart-spectral-matching/deployments/issues/7 tracks this work for later.

This is related to the review of PR https://github.com/smart-spectral-matching/ssm-service-catalog/pull/23

Other things included during debugging / development:
  - adds ability to run workflow manually (once it reaches the default branch) via workflow dispatch event for keycloak action yaml
  - updates versions of the actions to latest stable (i.e. checkout, docker ones like build and login, etc.)

